### PR TITLE
feat: enum for global alert types

### DIFF
--- a/src/enums/GlobalAlertTypeEnum.ts
+++ b/src/enums/GlobalAlertTypeEnum.ts
@@ -1,0 +1,5 @@
+export enum GlobalAlertTypeEnum {
+  error = "ERROR",
+  warning = "WARNING",
+  success = "SUCCESS",
+}

--- a/src/interfaces/AlertStateInterface.ts
+++ b/src/interfaces/AlertStateInterface.ts
@@ -1,6 +1,6 @@
 export interface AlertStateInterface {
   triggered?: boolean;
-  alertType: string;
+  alertType?: string;
   alertCode: string | number;
   alertMessage: string;
 }

--- a/src/pages/Device/Device.vue
+++ b/src/pages/Device/Device.vue
@@ -51,11 +51,11 @@
           throw { status: "000", statusText: "No stored sensors data found" };
         } else {
           sensorList.value = JSON.parse(storedSensors);
-          if (globalAlertStore.triggered) globalAlertStore.removeError();
+          if (globalAlertStore.triggered) globalAlertStore.clearAlert();
         }
       })
       .catch((err) => {
-        globalAlertStore.setError({ alertType: "ERROR", alertCode: err.status, alertMessage: err.statusText });
+        globalAlertStore.setError({ alertCode: err.status, alertMessage: err.statusText });
       });
   }
 

--- a/src/pages/DeviceList/DeviceList.vue
+++ b/src/pages/DeviceList/DeviceList.vue
@@ -25,12 +25,12 @@
     return deviceFetch
       .then(() => {
         deviceList.value = deviceStore.deviceList;
-        if (globalAlertStore.triggered) globalAlertStore.removeError();
+        if (globalAlertStore.triggered) globalAlertStore.clearAlert();
 
         return Promise.resolve(true);
       })
       .catch((err: OIOTEResponseType) => {
-        globalAlertStore.setError({ alertType: "ERROR", alertCode: err.status, alertMessage: err.statusText });
+        globalAlertStore.setError({ alertCode: err.status, alertMessage: err.statusText });
         return Promise.reject(false);
       });
   }

--- a/src/stores/globalAlertStore.ts
+++ b/src/stores/globalAlertStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { AlertStateInterface } from "../interfaces/AlertStateInterface";
+import { GlobalAlertTypeEnum } from "../enums/GlobalAlertTypeEnum";
 
 export const useAlertsStore = defineStore("alerts", {
   state: (): AlertStateInterface => {
@@ -13,12 +14,12 @@ export const useAlertsStore = defineStore("alerts", {
 
   actions: {
     setError(payload: AlertStateInterface) {
-      this.alertType = payload.alertType;
+      this.alertType = GlobalAlertTypeEnum.error;
       this.alertCode = payload.alertCode;
       this.alertMessage = payload.alertMessage;
       this.triggered = true;
     },
-    removeError() {
+    clearAlert() {
       this.alertType = "";
       this.alertCode = "";
       this.alertMessage = "";


### PR DESCRIPTION
- Using enum value to assign the type, instead of raw string
- Type is "auto" assigned, when calling "setError()"
- clearAlert() can be called on different alert types, instead of one

Closes #30