### PR TITLE
feat: new error type for not stored object

### DIFF
--- a/src/classes/NoDataStoredError.ts
+++ b/src/classes/NoDataStoredError.ts
@@ -1,0 +1,8 @@
+export class NoDataStoredError extends Error {
+  statusCode = "000";
+
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, NoDataStoredError.prototype);
+  }
+}

--- a/src/pages/Device/Device.vue
+++ b/src/pages/Device/Device.vue
@@ -5,6 +5,7 @@
 
   import RestClient from "../../rest/RestClient";
   import { OIOTEResponseType } from "../../types/OIOTEResponseType";
+  import { NoDataStoredError } from "../../classes/NoDataStoredError";
 
   import InteractiveMap from "../../components/maps/InteractiveMap.vue";
   import SensorMenu from "../../components/buttons/SensorMenu.vue";
@@ -44,14 +45,14 @@
       .then(() => {
         let storedSensors = sessionStorage.getItem(storageItem);
         if (!storedSensors) {
-          throw { status: "000", statusText: "No stored sensors data found" };
+          throw new NoDataStoredError("No stored sensors data found");
         } else {
           sensorList.value = JSON.parse(storedSensors) as SensorInterface[];
           if (globalAlertStore.triggered) globalAlertStore.clearAlert();
         }
       })
-      .catch((err) => {
-        globalAlertStore.setError({ alertCode: err.status, alertMessage: err.statusText });
+      .catch((err: OIOTEResponseType) => {
+        globalAlertStore.setError(err);
       });
   }
 

--- a/src/pages/DeviceList/DeviceList.vue
+++ b/src/pages/DeviceList/DeviceList.vue
@@ -30,7 +30,7 @@
         return Promise.resolve(true);
       })
       .catch((err: OIOTEResponseType) => {
-        globalAlertStore.setError({ alertCode: err.status, alertMessage: err.statusText });
+        globalAlertStore.setError(err);
         return Promise.reject(false);
       });
   }

--- a/src/rest/RestClient.ts
+++ b/src/rest/RestClient.ts
@@ -80,7 +80,7 @@ export default class RestClient {
   updateSensors = (deviceId: any, storageItem: string): Promise<OIOTEResponseType> => {
     return new Promise((resolve, reject) => {
       let userCookie: UserInterface = JSON.parse(Cookies.get("user") ?? "");
-      const noUserError = { id: "error", status: "*", statusTest: "No user is found! Try re-login again." };
+      const noUserError: OIOTEResponseType = { id: "error", status: "*", statusText: "No user is found! Try re-login again." };
       if (!userCookie) {
         reject(noUserError);
       }

--- a/src/stores/globalAlertStore.ts
+++ b/src/stores/globalAlertStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { AlertStateInterface } from "../interfaces/AlertStateInterface";
 import { GlobalAlertTypeEnum } from "../enums/GlobalAlertTypeEnum";
+import { OIOTEResponseType } from "../types/OIOTEResponseType";
 
 export const useAlertsStore = defineStore("alerts", {
   state: (): AlertStateInterface => {
@@ -13,10 +14,10 @@ export const useAlertsStore = defineStore("alerts", {
   },
 
   actions: {
-    setError(payload: AlertStateInterface) {
+    setError(payload: OIOTEResponseType) {
       this.alertType = GlobalAlertTypeEnum.error;
-      this.alertCode = payload.alertCode;
-      this.alertMessage = payload.alertMessage;
+      this.alertCode = payload.status;
+      this.alertMessage = payload.statusText;
       this.triggered = true;
     },
     clearAlert() {


### PR DESCRIPTION
Replace of the hardcoded error in Device
Fix of missing type annotation in RestClient
Fix of passing hardcoded response error in globalAlertStore

Closes #93 